### PR TITLE
Env passwords debug logs

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+.git
+.cache
+**/node_modules

--- a/.gitignore
+++ b/.gitignore
@@ -12,7 +12,7 @@ src/.baseDir.ts
 .vscode/
 
 *.swp
-
+*~
 
 # Directory used by example
 /notifications/
@@ -39,3 +39,4 @@ users_database.test.yml
 
 .suite
 .kube
+.idea

--- a/server/src/lib/AuthenticationSessionHandler.ts
+++ b/server/src/lib/AuthenticationSessionHandler.ts
@@ -34,6 +34,8 @@ export class AuthenticationSessionHandler {
     }
 
     if (!req.session.auth) {
+      logger.debug(req, "Session %s has no authentication information. Its internal id is: %s its current cookie is: %s",
+          req.sessionID, req.session.id, JSON.stringify(req.session.cookie));
       logger.debug(req, "Authentication session %s was undefined. Resetting..." +
         " If it's unexpected, make sure you are visiting the expected domain.", req.sessionID);
       AuthenticationSessionHandler.reset(req);

--- a/server/src/lib/BelongToDomain.ts
+++ b/server/src/lib/BelongToDomain.ts
@@ -1,8 +1,18 @@
 import { DomainExtractor } from "./DomainExtractor";
+import { IRequestLogger } from "./logging/IRequestLogger";
+import express = require("express");
 
-export function BelongToDomain(url: string, domain: string): boolean {
+export function BelongToDomain(url: string, domain: string, logger: IRequestLogger, req: express.Request): boolean {
   const urlDomain =  DomainExtractor.fromUrl(url);
-  if (!urlDomain) return false;
+  if (!urlDomain) {
+    logger.debug(req, "Unable to extract domain from url %s the url doesn't parse correctly.", url);
+    return false;
+  }
+  logger.debug(req,  "Extracted domain %s from url %s", urlDomain, url);
   const idx = urlDomain.indexOf(domain);
+  logger.debug(req,  "Found protected domain: %s in url extracted domain: %s at index: %s",
+      domain, urlDomain, idx);
+  logger.debug(req, "protected domain size: %s url extracted domain size: %s", domain.length, urlDomain.length);
+  logger.debug(req, "domain match url extracted: %s", idx + domain.length == urlDomain.length);
   return idx + domain.length == urlDomain.length;
 }

--- a/server/src/lib/Server.ts
+++ b/server/src/lib/Server.ts
@@ -74,16 +74,72 @@ export default class Server {
     const app = Express();
 
     const appConfiguration = ConfigurationParser.parse(configuration);
-
-    // We want to get the ldap binding password from the environment if it has been set, otherwise
-    // it will come from the configuration file
-    if (process.env.LDAP_BACKEND_PASSWORD) {
-      appConfiguration.authentication_backend.ldap.password = process.env.LDAP_BACKEND_PASSWORD;
-      that.globalLogger.debug("Got ldap binding password from environment");
-    }
-
     // by default the level of logs is info
     deps.winston.level = appConfiguration.logs_level;
+
+    // We want to get the ldap binding password from the environment if it has been set, otherwise it will come from
+    // the config file
+    if (process.env.LDAP_BACKEND_PASSWORD) {
+      if (appConfiguration.authentication_backend.ldap) {
+        appConfiguration.authentication_backend.ldap.password = process.env.LDAP_BACKEND_PASSWORD;
+        that.globalLogger.debug("Got ldap binding password from environment");
+      } else {
+        const erMsg =
+            "Environment variable LDAP_BACKEND_PASSWORD set, but no ldap configuration is specified in configuration file.";
+        that.globalLogger.error(erMsg);
+        throw new Error(erMsg);
+      }
+    }
+
+    // We want to get the session secret from the environment if it has been set, otherwise it will come from the
+    // config file
+    if (process.env.SESSION_SECRET) {
+      appConfiguration.session.secret = process.env.SESSION_SECRET;
+      that.globalLogger.debug("Got session secret from environment");
+    }
+
+    // We want to get the password for using an e-mail service from the environment if it has been set, otherwise it
+    // will come from the config file
+    if (process.env.EMAIL_SERVICE_PASSWORD) {
+      if (appConfiguration.notifier && appConfiguration.notifier.email) {
+        appConfiguration.notifier.email.password = process.env.EMAIL_SERVICE_PASSWORD;
+        that.globalLogger.debug("Got e-mail service notifier password from environment");
+      } else {
+        const erMsg = "Environment variable EMAIL_SERVICE_PASSWORD set, but no e-mail service is given in the " +
+            "notifier section of the configuration file.";
+        that.globalLogger.error(erMsg);
+        throw new Error(erMsg);
+      }
+    }
+
+    // We want to get the password for authenticating to an SMTP server for sending notifier e-mails if it has been set,
+    // otherwise it will come from the config file
+    if (process.env.SMTP_PASSWORD) {
+      if (appConfiguration.notifier && appConfiguration.notifier.smtp) {
+        appConfiguration.notifier.smtp.password = process.env.SMTP_PASSWORD;
+        that.globalLogger.debug("Got smtp service notifier password from environment");
+      } else {
+        const erMsg = "Environment variable SMTP_PASSWORD set, but no smtp entry is given in the notifier section of " +
+            "the configuration file.";
+        that.globalLogger.error(erMsg);
+        throw new Error(erMsg);
+      }
+    }
+
+    // We want to get the duo api secret key from the environment if it has been set, otherwise it will come from the
+    // config file
+    if (process.env.DUO_API_SECRET_KEY) {
+      if (appConfiguration.duo_api) {
+        appConfiguration.duo_api.secret_key = process.env.DUO_API_SECRET_KEY;
+        that.globalLogger.debug("Got duo api secret from environment");
+      } else {
+        const erMsg =
+            "Environment variable DUO_API_SECRET_KEY set, but no duo_api section given in the configuration file.";
+        that.globalLogger.error(erMsg);
+        throw new Error(erMsg);
+      }
+    }
+
     this.displayConfigurations(appConfiguration);
 
     return this.setup(appConfiguration, app, deps)

--- a/server/src/lib/Server.ts
+++ b/server/src/lib/Server.ts
@@ -75,6 +75,13 @@ export default class Server {
 
     const appConfiguration = ConfigurationParser.parse(configuration);
 
+    // We want to get the ldap binding password from the environment if it has been set, otherwise
+    // it will come from the configuration file
+    if (process.env.LDAP_BACKEND_PASSWORD) {
+      appConfiguration.authentication_backend.ldap.password = process.env.LDAP_BACKEND_PASSWORD;
+      that.globalLogger.debug("Got ldap binding password from environment");
+    }
+
     // by default the level of logs is info
     deps.winston.level = appConfiguration.logs_level;
     this.displayConfigurations(appConfiguration);

--- a/server/src/lib/routes/verify/Get.ts
+++ b/server/src/lib/routes/verify/Get.ts
@@ -17,9 +17,10 @@ async function verifyWithSelectedMethod(req: Express.Request, res: Express.Respo
   vars: ServerVariables, authSession: AuthenticationSession | undefined)
   : Promise<void> {
   if (HasHeader(req, Constants.HEADER_PROXY_AUTHORIZATION)) {
+    vars.logger.debug(req, "Got PROXY_AUTHORIZATION header checking basic auth");
     await GetBasicAuth(req, res, vars);
-  }
-  else {
+  } else {
+    vars.logger.debug(req, "Checking session cookie");
     await GetSessionCookie(req, res, vars, authSession);
   }
 }
@@ -49,6 +50,7 @@ async function unsafeGet(vars: ServerVariables, req: Express.Request, res: Expre
     }
 
     // Reply with an error.
+    vars.logger.error(req, "Got an error state when processing verify. Error was: %s", err.toString());
     throw err;
   }
 }


### PR DESCRIPTION
This adds the following major features:
- The ability to have passwords passed in via environment variables rather than the configuration file

This feature is needed to allow the use of Kubernetes secrets when deploying Authelia in Kubernetes via a Docker image

This adds the following minor features:
- Better debugging output for domain/subdomain comparison
- additions to .gitignore for vim and idea editors
- A .dockerignore file to make the copy of the initial context to the docker daemon go faster

These features were necessary to increase developer productivity and make it simpler to track down domain/cookie issues.