### PR TITLE
Changed to using node 10.16.0 to get better ldaps support.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rajhakorithrien/node:10.16.0-alpine-tls-fix
+FROM node:10.16.0-alpine
 
 WORKDIR /usr/src
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "authelia": "./dist/server/src/index.js"
   },
   "engines": {
-    "node": ">=8.0.0 <10.16.0"
+    "node": ">=8.0.0 <10.0.0"
   },
   "scripts": {
     "start": "./scripts/authelia-scripts suites start",


### PR DESCRIPTION
Removes use of custom node version for merger into upstream